### PR TITLE
Fix publish images Github action

### DIFF
--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -2,7 +2,8 @@ name: Publish Docker image
 
 on:
   push:
-    tags: '*'
+    tags:
+      - '*'
 
 jobs:
   push_to_registry:
@@ -13,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - name: setup the environment
         run: |
-          TAG=${GITHUB_REF#refs/heads/}
+          TAG=${GITHUB_REF#refs/*/}
           REPO="docker.io/ohiosupercomputer"
           echo "LATEST_IMG=$REPO/ood-k8s-utils:latest" >> $GITHUB_ENV
           echo "VERSIONED_IMG=$REPO/ood-k8s-utils:$TAG" >> $GITHUB_ENV


### PR DESCRIPTION
A few issues. Main fix was to use `yaml` extension and not `yml` and also to fix how the tag is extracted from `GITHUB_REF` as the previous behavior was production invalid docker tag names as it didn't actually strip off the `ref/..` part.

Worked here: https://github.com/treydock/ood-k8s-utils/runs/2695405550?check_suite_focus=true - the login / push failed because secrets don't exist in my fork but the actual action ran and built the necessary image and tagged it.